### PR TITLE
Clean up margins and width of command palette

### DIFF
--- a/stylesheets/zen.less
+++ b/stylesheets/zen.less
@@ -9,6 +9,11 @@
     width: 700px;
     margin: 0 auto;
     margin-top: 40px;
+
+    &.mini {
+      margin-top: 0;
+      width: 478px !important;
+    }
   }
 
   .gutter, .status-bar, .tab-bar, .panel-left {


### PR DESCRIPTION
First of all, I'm loving Atom and the Zen package in particular. As was mentioned in Issue https://github.com/defunkt/zen/issues/1, there's some strange behavior going on with the Command Palette in Zen mode. After poking around a bit I saw that the main editor area and the command palette both share the same class `.editor`.

I was able to clean up the look for now by making a couple quick fixes. Unfortunately, they are slightly hacky (like having to use !important :frowning:). I feel like a better longterm solution would be to give the main editor area and the command palette distinct classes that could be modified in lieu of `.editor`. 

Before: 
![Before image](http://cl.ly/image/462t2b3B172Y/Screen%20Shot%202014-02-28%20at%204.44.16%20PM.png)

After:
![After image](http://f.cl.ly/items/3q260y3I0P2V230m1h0m/Screen%20Shot%202014-02-28%20at%204.43.33%20PM.png)

I'm looking forward to your thoughts!

EDIT: An alternately hacky approach that occurred to me is that I could have had the zen toggle add the classes I was talking about before and then change the .editor css to the added class. This would prevent any modifications from being necessary for `.mini`
