### PR TITLE
Passing tests

### DIFF
--- a/spec/zen-spec.coffee
+++ b/spec/zen-spec.coffee
@@ -1,4 +1,5 @@
 Zen = require '../lib/zen'
+{WorkspaceView} = require 'atom'
 
 # Use the command `window:run-package-specs` (cmd-alt-ctrl-p) to run specs.
 #
@@ -14,7 +15,7 @@ describe "Zen", ->
 
   describe "when the zen:toggle event is triggered", ->
     it "attaches and then detaches the view", ->
-      expect(atom.workspaceView.find('.zen')).not.toExist()
+      expect(atom.workspaceView).not.toHaveClass('zen')
 
       # This is an activation event, triggering it will cause the package to be
       # activated.
@@ -24,6 +25,6 @@ describe "Zen", ->
         activationPromise
 
       runs ->
-        expect(atom.workspaceView.find('.zen')).toExist()
+        expect(atom.workspaceView).toHaveClass('zen')
         atom.workspaceView.trigger 'zen:toggle'
-        expect(atom.workspaceView.find('.zen')).not.toExist()
+        expect(atom.workspaceView).not.toHaveClass('zen')

--- a/spec/zen-view-spec.coffee
+++ b/spec/zen-view-spec.coffee
@@ -1,6 +1,0 @@
-ZenView = require '../lib/zen-view'
-{WorkspaceView} = require 'atom'
-
-describe "ZenView", ->
-  it "has one valid test", ->
-    expect("life").toBe "easy"


### PR DESCRIPTION
As reported in https://github.com/defunkt/zen/issues/5 tests were not passing. It seems that there was an extra spec file that was including a file that did not exist. Also, the tests were not properly defining WorkspaceView and they were looking for the `atom.workspaceView` to contain an element with the class `zen`. However, this package is actually adding the `zen` class to the `atom.workspaceView` itself.
