### PR TITLE
Add option to keep tree view while in zen mode

### DIFF
--- a/lib/zen.coffee
+++ b/lib/zen.coffee
@@ -2,16 +2,25 @@ module.exports =
   activate: (state) ->
     atom.workspaceView.command "zen:toggle", => @toggle()
 
+  configDefaults:
+    hideTreeView: true
+
   toggle: ->
     workspace = atom.workspaceView
-    tabs = atom.packages.activePackages.tabs
+    tabs = atom.packages.getActivePackage('tabs')
+    treeView = atom.packages.getActivePackage('tree-view')
 
     if workspace.is '.zen'
       bgColor = workspace.find('.panes .pane').css('background-color')
       tabs?.activate()
+      treeView?.activate()
+
     else
       bgColor = workspace.find('.editor-colors').css('background-color')
       tabs?.deactivate()
+
+      if atom.config.get('zen.hideTreeView')
+        treeView?.deactivate()
 
     workspace.find('.panes .pane').css('background-color', bgColor)
     workspace.toggleClass 'zen'

--- a/spec/zen-spec.coffee
+++ b/spec/zen-spec.coffee
@@ -27,3 +27,21 @@ describe "Zen", ->
         expect(atom.workspaceView.find('.zen')).toExist()
         atom.workspaceView.trigger 'zen:toggle'
         expect(atom.workspaceView.find('.zen')).not.toExist()
+
+  describe "when the `zen.hideTreeView` config is false", ->
+    it "allows the tree view to remain active when entering zen mode", ->
+      atom.config.set('zen.hideTreeView', false)
+      atom.packages.activatePackage('tree-view')
+
+      runs ->
+        atom.workspaceView.trigger 'tree-view:toggle'
+        expect(atom.workspaceView.find(".tree-view")).toExist()
+
+  describe "when the `zen.hideTreeView` config is true", ->
+    it "deactivates the tree view when entering zen mode", ->
+      atom.config.set('zen.hideTreeView', true)
+      atom.packages.activatePackage('tree-view')
+
+      runs ->
+        atom.workspaceView.trigger 'tree-view:toggle'
+        expect(atom.workspaceView.find(".tree-view")).not.toExist()

--- a/stylesheets/zen.less
+++ b/stylesheets/zen.less
@@ -11,7 +11,7 @@
     margin-top: 40px;
   }
 
-  .gutter, .status-bar, .tab-bar, .panel-left {
+  .gutter, .status-bar {
     display: none;
   }
 }


### PR DESCRIPTION
This is a change I did locally for my workflow and I figured I'd see if I could get it merged in upstream. Obviously most people want zen mode to have as few options as possible in it, but I do like the option to still open the tree view while in it. As it stands, it's a major hassle to have to leave zen mode to do one of my most common actions. 

I left the tree view as being hidden by default so that there would be absolutely no change to the end user unless desired.

![Preview](http://cl.ly/image/1c2I2w2G2N3c/zenview.gif)

This should probably not be merged in until after https://github.com/defunkt/zen/pull/6 as I built on top of that.
