### PR TITLE
Darken & embolden GFM Headings

### DIFF
--- a/stylesheets/zen.less
+++ b/stylesheets/zen.less
@@ -14,4 +14,9 @@
   .gutter, .status-bar, .tab-bar, .panel-left {
     display: none;
   }
+  
+  .markup.heading.gfm {
+    -webkit-filter: brightness(0.3);
+    font-weight: bold;
+  }
 }


### PR DESCRIPTION
Make headings in GFM documents stand out by darkening and emboldening them.

Do you even want syntax-specific markup in zen, and would this be the right place for it? I'd personally love to see Zen serve as a beautiful markdown editing view, so I'm also wondering if there is a way to force soft-wrap, etc.

Note: While I personally like this style w/ the dark theme, I haven't tried it out on the light theme yet.
