### PR TITLE
Fix background color

### DIFF
--- a/stylesheets/zen.less
+++ b/stylesheets/zen.less
@@ -3,8 +3,13 @@
 // See https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
 // for a full listing of what's available.
 @import "ui-variables";
+@import "syntax-variables";
 
 .zen {
+  .item-views {
+    background-color:  @syntax-background-color;
+  }
+
   .editor:not(.mini) {
     width: 700px;
     margin: 0 auto;


### PR DESCRIPTION
Sometimes the background color differs from editor background color like in the screenshot, where we have that gray around the white editor background. This PR fixes this.

![screenshot 2014-03-12 12 29 33](https://f.cloud.github.com/assets/31248/2408937/1ce267fa-aaa5-11e3-9e3a-ed34575a8346.png)
