### PR TITLE
Change width to 90%

### DIFF
--- a/stylesheets/zen.less
+++ b/stylesheets/zen.less
@@ -11,7 +11,7 @@
   }
 
   .editor:not(.mini) {
-    width: 700px;
+    width: 90%;
     margin: 0 auto;
     margin-top: 40px;
   }


### PR DESCRIPTION
I found it frustrating that it was fixed at 700px so that anything that went over that I had to scroll to see the code, and when typing it would bounce back and forth. This updates it to be a dynamic width so that it is responsive and allows for more space.
