### PR TITLE
Custom zen style example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ fullscreen command:
 Customize the experience in your Atom stylesheet (Atom -> Open Your Stylesheet)
 
 ```
-.zen .wrap-guide { 
-  visibility: hidden; 
+.zen .wrap-guide {
+  visibility: hidden;
 }
 
 .zen .editor {
-  width: 800px;
+  width: 80%;
+  max-width: 800px;
   font-size:16px;
 }
 ```


### PR DESCRIPTION
When I enabled zen it was full-width. Thought it would be good to mention that you can fix this and add other customizations in your Atom stylesheet. 
