### PR TITLE
don't exit on escape

### DIFF
--- a/keymaps/zen.cson
+++ b/keymaps/zen.cson
@@ -1,6 +1,3 @@
-'.workspace.zen':
-  'escape': 'zen:toggle'
-
 '.platform-darwin .workspace':
   'ctrl-shift-cmd-F': 'zen:toggle'
   'cmd-ctrl-z': 'zen:toggle'


### PR DESCRIPTION
Fixes #38. Exiting on `esc` interferes with the search feature. It's not 'zen' if you keep exiting by accident all the time ;)