### PR TITLE
Fix Zen-mode background colour. 

### DIFF
--- a/lib/zen.coffee
+++ b/lib/zen.coffee
@@ -43,7 +43,7 @@ module.exports =
       editorView.css 'width', "#{charWidth * width}px"
 
       # Get current background color
-      bgColor = workspace.find('.editor-colors').css 'background-color'
+      bgColor = workspace.find('atom-text-editor').css 'background-color'
 
       # Enter fullscreen
       atom.setFullScreen true if fullscreen


### PR DESCRIPTION
The old selector of ‘.editor-color’ in Atom 0.177.0 now returns []. Which is probably causing this:

![screen shot 2015-02-07 at 20 13 51](https://cloud.githubusercontent.com/assets/111891/6093767/c6576ae6-af05-11e4-93b0-ea6f2a08abe7.png)

Updating it to ‘atom-text-editor’ seems to fix this:
![screen shot 2015-02-07 at 20 15 52](https://cloud.githubusercontent.com/assets/111891/6093778/1072f9b0-af06-11e4-8c8d-8c1130f267df.png)


