### PR TITLE
Add setting for soft wrapping in zen mode

### DIFF
--- a/lib/zen.coffee
+++ b/lib/zen.coffee
@@ -15,6 +15,10 @@ module.exports =
       description: 'Show the word-count if you have the package installed.'
       type: 'boolean'
       default: false
+    softWrap:
+      description: 'Enables / Disables soft wrapping when Zen is active.'
+      type: 'boolean'
+      default: atom.config.get 'editor.softWrap'
     width:
       type: 'integer'
       default: atom.config.get 'editor.preferredLineLength'
@@ -30,6 +34,7 @@ module.exports =
     # should really check current fullsceen state
     fullscreen = atom.config.get 'Zen.fullscreen'
     width = atom.config.get 'Zen.width'
+    softWrap = atom.config.get 'Zen.softWrap'
 
     if editor is undefined # e.g. settings-view
       atom.notifications.addInfo 'Zen cannot be achieved in this view.'
@@ -50,14 +55,14 @@ module.exports =
       body.setAttribute 'data-zen', 'true'
 
       # Soft Wrap
-      # set it so it's true for all new editors you open in zen
-      if atom.config.get('editor.softWrap') is false
-        atom.config.set('editor.softWrap', true)
-        # remember to put it back later
+      # Use zen soft wrapping setting's to override the default settings
+      if atom.config.get('editor.softWrap') isnt softWrap
+        atom.config.set('editor.softWrap', softWrap)
+        # restore default when leaving zen mode
         @unSetSoftWrap = true
-      if editor.isSoftWrapped() is false
-        editor.setSoftWrapped true
-        # and remember to set is back later
+      if editor.isSoftWrapped() isnt softWrap
+        editor.setSoftWrapped softWrap
+        # restore default when leaving zen mode
         @unSoftWrap = true
 
       # Set width
@@ -100,14 +105,14 @@ module.exports =
       # Leave fullscreen
       atom.setFullScreen false if fullscreen
 
-      # Disable soft wrap if it was disabled when we zen'd
+      # Restore previous soft wrap setting when leaving zen mode
       if @unSoftWrap
-        editor.setSoftWrapped false
+        editor.setSoftWrapped (not softWrap)
         @unSoftWrap = null
 
-      # Reset the config for softwrap if it was enabled when we zen'd
+      # Reset the config for softwrap when leaving zen mode
       if @unSetSoftWrap
-        atom.config.set('editor.softWrap', false)
+        atom.config.set('editor.softWrap', (not softWrap))
 
       # Unset the width
       $('atom-text-editor:not(.mini)').css 'width', ''


### PR DESCRIPTION
As discussed in #59, this adds a custom setting to Zen which allows the user to enable / disable the soft wrapping while in Zen mode regardless of the default soft wrapping settings.

It is my first time working with CoffeeScript so I hope everything is okay.

Cheers,
Robert