### PR TITLE
Add more options for the tab style while Zen is active

### DIFF
--- a/lib/zen.coffee
+++ b/lib/zen.coffee
@@ -7,10 +7,11 @@ module.exports =
     fullscreen:
       type: 'boolean'
       default: true
-    hideTabs:
-      description: 'Disable to keep the current tab visible when Zen.'
-      type: 'boolean'
-      default: true
+    tabs:
+      description: 'Determines the tab style used while Zen is active.'
+      type: 'string'
+      default: 'hidden'
+      enum: ['hidden', 'single', 'multiple']
     showWordCount:
       description: 'Show the word-count if you have the package installed.'
       type: 'boolean'
@@ -43,10 +44,8 @@ module.exports =
         atom.notifications.addInfo 'Zen cannot be achieved in this view.'
         return
 
-      if atom.config.get 'Zen.hideTabs'
-        body.setAttribute 'data-zen-tabs', 'hidden'
-      else
-        body.setAttribute 'data-zen-tabs', 'visible'
+      if atom.config.get 'Zen.tabs'
+        body.setAttribute 'data-zen-tabs', atom.config.get 'Zen.tabs'
 
       if atom.config.get 'Zen.showWordCount'
         body.setAttribute 'data-zen-word-count', 'visible'

--- a/styles/zen.less
+++ b/styles/zen.less
@@ -52,16 +52,56 @@
     }
   }
 
-  &[data-zen-tabs="visible"] {
+  &[data-zen-tabs="multiple"], &[data-zen-tabs="single"] {
     .tab-bar {
       display: flex;
       justify-content: center;
+      background: @syntax-background-color;
+      box-shadow: none;
+      &:after {
+        display: none;
+      }
+      .tab {
+        display: block;
+        box-shadow: none;
+        &, &:before, &:after {
+          background-image: none;
+          box-shadow: none;
+        }
+        .close-icon {
+          display: none;
+        }
+        .title {
+          text-align: center;
+        }
+      }
+    }
+  }
+
+  &[data-zen-tabs="multiple"] {
+    .tab-bar {
+      .tab {
+        opacity: .20;
+      }
+      .active {
+        display: block;
+        text-align: center;
+        width: 100%;
+        opacity: 0.85;
+      }
+    }
+  }
+
+  &[data-zen-tabs="single"] {
+    .tab-bar {
       .tab {
         display: none;
       }
       .active {
         display: block;
+        text-align: center;
         width: 100%;
+        opacity: 0.85;
       }
     }
   }


### PR DESCRIPTION
Hello once again,

this time I extended the option for hiding / showing tabs in Zen mode.

Added a dropdown menu to the settings which lets the user choose between
the 'hidden', 'single' and 'multiple' options.

The 'hidden' option is the default option and removes the whole tab bar
when Zen is active. The 'single' option displays only the tab of the
currently edited file and the 'multiple' option displays multiple tabs
at once.

Both the single and multiple options change the style of the open tabs
to keep them unobtrusive and zen-like. It removes all decorations, only
shows the title of the tabs and slightly highlights the currently active
one.

Before:
![before](https://cloud.githubusercontent.com/assets/11627131/7547900/2740597a-f5f7-11e4-8685-c91e48e5a1ea.png)

After:
![after](https://cloud.githubusercontent.com/assets/11627131/7547901/2b1bdf06-f5f7-11e4-9cdf-4752d77f10cb.png)

Multiple Tabs (new option):
![multiple](https://cloud.githubusercontent.com/assets/11627131/7547903/3175af12-f5f7-11e4-860f-026a4142aabf.png)

Best wishes,
Robert