### PR TITLE
Added style to remove atom footer from Zen mode

### DIFF
--- a/styles/zen.less
+++ b/styles/zen.less
@@ -19,6 +19,10 @@
   atom-workspace atom-panel-container.left:empty {
     padding: 0;
   }
+  
+  atom-panel-container.footer {
+    display: none;
+  }
 
   .tab-bar {
     display: none;


### PR DESCRIPTION
In recent versions of Atom the footer didn't disappear in Zen mode. I've added the Less functionality to remove it from view.